### PR TITLE
fix(saucelabs): add references to saucelabs config in pipeline.yml

### DIFF
--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -30,6 +30,13 @@ stages:
         job: distribution
     triggers:
       - type: stage
+    properties:
+      - name: SAUCE_USERNAME
+        value: ${SAUCE_USER}
+        type: text
+      - name: SAUCE_ACCESS_KEY
+        value: ${SAUCE_KEY}
+        type: text
     jobs:
       - name: lint
         type: tester


### PR DESCRIPTION
enables the transfer of configuration parameters from the prompt to process.env
